### PR TITLE
disable fail fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
     runs-on: ${{matrix.os}}-latest
     timeout-minutes: 30
     strategy:
-      fail-fast: false
       matrix:
         rust-channel: [stable, beta, nightly]
         os: [ubuntu, windows]


### PR DESCRIPTION
for some reason ci pass finishes before matrix jobs? maybe this will fix it?